### PR TITLE
chore(copilot): Update PR compliance workflow

### DIFF
--- a/.github/workflows/pr-compliance-autofill.yml
+++ b/.github/workflows/pr-compliance-autofill.yml
@@ -8,6 +8,14 @@ on:
         required: true
         default: docs/release-notes/artifacts
         description: The directory where your change artifacts live
+    secrets:
+      token:
+        required: false
+        description: >
+          A GitHub token with contents:write permission.
+          Falls back to the automatic GITHUB_TOKEN when not provided.
+          Pass a PAT or GitHub App token if your calling workflow
+          needs write access from fork PRs (e.g. via pull_request_target).
 
 jobs:
   check-release-note-artifact:
@@ -58,9 +66,9 @@ jobs:
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           PR_BRANCH: ${{ github.event.pull_request.head.ref }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.token || secrets.GITHUB_TOKEN }}
         run: |
-          set -euo pipefail
+          set -uo pipefail
 
           MODIFIED=false
 
@@ -96,16 +104,25 @@ jobs:
               echo "Updated PR link in ${ARTIFACT_FILE}"
 
               # Commit the modified file via the GitHub API (produces a verified commit)
-              FILE_SHA=$(gh api "/repos/${GITHUB_REPOSITORY}/contents/${ARTIFACT_FILE}?ref=${PR_BRANCH}" \
+              # Wrapped in error handling so fork PRs with read-only tokens do not
+              # fail the entire workflow — the compliance check still enforces
+              # artifact presence even when the commit cannot be pushed.
+              if ! FILE_SHA=$(gh api "/repos/${GITHUB_REPOSITORY}/contents/${ARTIFACT_FILE}?ref=${PR_BRANCH}" \
                 --jq '.sha' \
-                -H "Accept: application/vnd.github+json")
+                -H "Accept: application/vnd.github+json" 2>&1); then
+                echo "::warning::Could not read file SHA for ${ARTIFACT_FILE}. The PR link was not auto-populated, likely due to insufficient write permissions (e.g. fork PR). A maintainer can populate the link after merge."
+                continue
+              fi
 
-              gh api --method PUT "/repos/${GITHUB_REPOSITORY}/contents/${ARTIFACT_FILE}" \
+              if ! gh api --method PUT "/repos/${GITHUB_REPOSITORY}/contents/${ARTIFACT_FILE}" \
                 -H "Accept: application/vnd.github+json" \
                 -f message="Auto-populate PR link in change artifact" \
                 -f content="$(base64 -w 0 < "${ARTIFACT_FILE}")" \
                 -f sha="${FILE_SHA}" \
-                -f branch="${PR_BRANCH}" > /dev/null
+                -f branch="${PR_BRANCH}" > /dev/null 2>&1; then
+                echo "::warning::Could not commit updated artifact ${ARTIFACT_FILE}. The PR link was not auto-populated, likely due to insufficient write permissions (e.g. fork PR). A maintainer can populate the link after merge."
+                continue
+              fi
             fi
           done <<< "${{ steps.check-artifact.outputs.MATCHING_FILES }}"
 

--- a/.github/workflows/pr-compliance-autofill.yml
+++ b/.github/workflows/pr-compliance-autofill.yml
@@ -1,0 +1,115 @@
+name: Check for release notes artifact
+
+on:
+  workflow_call:
+    inputs:
+      change-artifact-dir:
+        type: string
+        required: true
+        default: docs/release-notes/artifacts
+        description: The directory where your change artifacts live
+
+jobs:
+  check-release-note-artifact:
+    # run only for PRs not opened by a bot
+    if: ${{ github.event.pull_request.user.type != 'Bot' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Check for added or changed artifact
+        id: check-artifact
+        # Only run this step when the PR does NOT have the "artifact opt out" label
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-release-note') }}
+        run: |
+          set -euo pipefail
+
+          BASE_SHA=${{ github.event.pull_request.base.sha }}
+          HEAD_SHA=${{ github.event.pull_request.head.sha }}
+
+          # List added or modified files between base and head
+          CHANGED_FILES=$(git diff --name-status "${BASE_SHA}" "${HEAD_SHA}" | awk '$1 == "A" || $1 == "M" { print $2 }' || true)
+
+          # Filter for YAML files under ${{ inputs.change-artifact-dir }}
+          MATCHING=$(printf "%s\n" "${CHANGED_FILES}" | grep -E '^${{ inputs.change-artifact-dir }}.*\.yaml$' || true)
+
+          if [ -z "${MATCHING}" ]; then
+            echo "ERROR: No YAML file added or updated under ${{ inputs.change-artifact-dir }} in this PR."
+            echo "Please add or update a change artifact file that summarizes your pull request under ${{ inputs.change-artifact-dir }}."
+            exit 1
+          fi
+
+          echo "Found the following release-notes artifact(s) added or updated in this PR:"
+          printf "%s\n" "${MATCHING}"
+
+          # Export matching files for subsequent steps
+          echo "MATCHING_FILES<<EOF" >> "$GITHUB_OUTPUT"
+          printf "%s\n" "${MATCHING}" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Auto-populate PR link in change artifacts
+        if: ${{ steps.check-artifact.outputs.MATCHING_FILES != '' }}
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_BRANCH: ${{ github.event.pull_request.head.ref }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          MODIFIED=false
+
+          while IFS= read -r ARTIFACT_FILE; do
+            [ -z "${ARTIFACT_FILE}" ] && continue
+
+            # Count how many changes entries exist
+            ENTRY_COUNT=$(yq '.changes | length' "${ARTIFACT_FILE}")
+
+            FILE_CHANGED=false
+            for (( i=0; i<ENTRY_COUNT; i++ )); do
+              # Check if the current PR URL is already in .changes[i].urls.pr
+              HAS_PR=$(yq ".changes[${i}].urls.pr[] | select(. == \"${PR_URL}\")" "${ARTIFACT_FILE}")
+              if [ -n "${HAS_PR}" ]; then
+                echo "PR URL already present in .changes[${i}].urls.pr of ${ARTIFACT_FILE}"
+                continue
+              fi
+
+              # Check if the list contains only empty strings
+              NON_EMPTY=$(yq ".changes[${i}].urls.pr[] | select(. != \"\")" "${ARTIFACT_FILE}")
+              if [ -z "${NON_EMPTY}" ]; then
+                # Replace the empty string(s) with the PR URL
+                yq -i ".changes[${i}].urls.pr = [\"${PR_URL}\"]" "${ARTIFACT_FILE}"
+              else
+                # Append the PR URL to the existing list
+                yq -i ".changes[${i}].urls.pr += [\"${PR_URL}\"]" "${ARTIFACT_FILE}"
+              fi
+              FILE_CHANGED=true
+            done
+
+            if [ "${FILE_CHANGED}" = true ]; then
+              MODIFIED=true
+              echo "Updated PR link in ${ARTIFACT_FILE}"
+
+              # Commit the modified file via the GitHub API (produces a verified commit)
+              FILE_SHA=$(gh api "/repos/${GITHUB_REPOSITORY}/contents/${ARTIFACT_FILE}?ref=${PR_BRANCH}" \
+                --jq '.sha' \
+                -H "Accept: application/vnd.github+json")
+
+              gh api --method PUT "/repos/${GITHUB_REPOSITORY}/contents/${ARTIFACT_FILE}" \
+                -H "Accept: application/vnd.github+json" \
+                -f message="Auto-populate PR link in change artifact" \
+                -f content="$(base64 -w 0 < "${ARTIFACT_FILE}")" \
+                -f sha="${FILE_SHA}" \
+                -f branch="${PR_BRANCH}" > /dev/null
+            fi
+          done <<< "${{ steps.check-artifact.outputs.MATCHING_FILES }}"
+
+          if [ "${MODIFIED}" = false ]; then
+            echo "All artifact PR links already include this PR."
+          fi
+

--- a/.github/workflows/pr-compliance.yml
+++ b/.github/workflows/pr-compliance.yml
@@ -53,7 +53,7 @@ jobs:
           printf "%s\n" "${MATCHING}" >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 
-      - name: Auto-populate PR link in artifacts
+      - name: Auto-populate PR link in change artifacts
         if: ${{ steps.check-artifact.outputs.MATCHING_FILES != '' }}
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
@@ -102,7 +102,7 @@ jobs:
 
               gh api --method PUT "/repos/${GITHUB_REPOSITORY}/contents/${ARTIFACT_FILE}" \
                 -H "Accept: application/vnd.github+json" \
-                -f message="Auto-populate PR link in release artifact" \
+                -f message="Auto-populate PR link in change artifact" \
                 -f content="$(base64 -w 0 < "${ARTIFACT_FILE}")" \
                 -f sha="${FILE_SHA}" \
                 -f branch="${PR_BRANCH}" > /dev/null

--- a/.github/workflows/pr-compliance.yml
+++ b/.github/workflows/pr-compliance.yml
@@ -14,17 +14,13 @@ jobs:
     # run only for PRs not opened by a bot
     if: ${{ github.event.pull_request.user.type != 'Bot' }}
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - name: Checkout PR
         uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Check for added or changed artifact
-        id: check-artifact
         # Only run this step when the PR does NOT have the "artifact opt out" label
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-release-note') }}
         run: |
@@ -47,69 +43,3 @@ jobs:
 
           echo "Found the following release-notes artifact(s) added or updated in this PR:"
           printf "%s\n" "${MATCHING}"
-
-          # Export matching files for subsequent steps
-          echo "MATCHING_FILES<<EOF" >> "$GITHUB_OUTPUT"
-          printf "%s\n" "${MATCHING}" >> "$GITHUB_OUTPUT"
-          echo "EOF" >> "$GITHUB_OUTPUT"
-
-      - name: Auto-populate PR link in change artifacts
-        if: ${{ steps.check-artifact.outputs.MATCHING_FILES != '' }}
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          PR_BRANCH: ${{ github.event.pull_request.head.ref }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-
-          MODIFIED=false
-
-          while IFS= read -r ARTIFACT_FILE; do
-            [ -z "${ARTIFACT_FILE}" ] && continue
-
-            # Count how many changes entries exist
-            ENTRY_COUNT=$(yq '.changes | length' "${ARTIFACT_FILE}")
-
-            FILE_CHANGED=false
-            for (( i=0; i<ENTRY_COUNT; i++ )); do
-              # Check if the current PR URL is already in .changes[i].urls.pr
-              HAS_PR=$(yq ".changes[${i}].urls.pr[] | select(. == \"${PR_URL}\")" "${ARTIFACT_FILE}")
-              if [ -n "${HAS_PR}" ]; then
-                echo "PR URL already present in .changes[${i}].urls.pr of ${ARTIFACT_FILE}"
-                continue
-              fi
-
-              # Check if the list contains only empty strings
-              NON_EMPTY=$(yq ".changes[${i}].urls.pr[] | select(. != \"\")" "${ARTIFACT_FILE}")
-              if [ -z "${NON_EMPTY}" ]; then
-                # Replace the empty string(s) with the PR URL
-                yq -i ".changes[${i}].urls.pr = [\"${PR_URL}\"]" "${ARTIFACT_FILE}"
-              else
-                # Append the PR URL to the existing list
-                yq -i ".changes[${i}].urls.pr += [\"${PR_URL}\"]" "${ARTIFACT_FILE}"
-              fi
-              FILE_CHANGED=true
-            done
-
-            if [ "${FILE_CHANGED}" = true ]; then
-              MODIFIED=true
-              echo "Updated PR link in ${ARTIFACT_FILE}"
-
-              # Commit the modified file via the GitHub API (produces a verified commit)
-              FILE_SHA=$(gh api "/repos/${GITHUB_REPOSITORY}/contents/${ARTIFACT_FILE}?ref=${PR_BRANCH}" \
-                --jq '.sha' \
-                -H "Accept: application/vnd.github+json")
-
-              gh api --method PUT "/repos/${GITHUB_REPOSITORY}/contents/${ARTIFACT_FILE}" \
-                -H "Accept: application/vnd.github+json" \
-                -f message="Auto-populate PR link in change artifact" \
-                -f content="$(base64 -w 0 < "${ARTIFACT_FILE}")" \
-                -f sha="${FILE_SHA}" \
-                -f branch="${PR_BRANCH}" > /dev/null
-            fi
-          done <<< "${{ steps.check-artifact.outputs.MATCHING_FILES }}"
-
-          if [ "${MODIFIED}" = false ]; then
-            echo "All artifact PR links already include this PR."
-          fi
-

--- a/.github/workflows/pr-compliance.yml
+++ b/.github/workflows/pr-compliance.yml
@@ -96,10 +96,9 @@ jobs:
               echo "Updated PR link in ${ARTIFACT_FILE}"
 
               # Commit the modified file via the GitHub API (produces a verified commit)
-              FILE_SHA=$(gh api "/repos/${GITHUB_REPOSITORY}/contents/${ARTIFACT_FILE}" \
+              FILE_SHA=$(gh api "/repos/${GITHUB_REPOSITORY}/contents/${ARTIFACT_FILE}?ref=${PR_BRANCH}" \
                 --jq '.sha' \
-                -H "Accept: application/vnd.github+json" \
-                -f ref="${PR_BRANCH}")
+                -H "Accept: application/vnd.github+json")
 
               gh api --method PUT "/repos/${GITHUB_REPOSITORY}/contents/${ARTIFACT_FILE}" \
                 -H "Accept: application/vnd.github+json" \

--- a/.github/workflows/pr-compliance.yml
+++ b/.github/workflows/pr-compliance.yml
@@ -43,3 +43,4 @@ jobs:
 
           echo "Found the following release-notes artifact(s) added or updated in this PR:"
           printf "%s\n" "${MATCHING}"
+

--- a/.github/workflows/pr-compliance.yml
+++ b/.github/workflows/pr-compliance.yml
@@ -14,13 +14,17 @@ jobs:
     # run only for PRs not opened by a bot
     if: ${{ github.event.pull_request.user.type != 'Bot' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout PR
         uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Check for added or changed artifact
+        id: check-artifact
         # Only run this step when the PR does NOT have the "artifact opt out" label
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-release-note') }}
         run: |
@@ -43,4 +47,70 @@ jobs:
 
           echo "Found the following release-notes artifact(s) added or updated in this PR:"
           printf "%s\n" "${MATCHING}"
+
+          # Export matching files for subsequent steps
+          echo "MATCHING_FILES<<EOF" >> "$GITHUB_OUTPUT"
+          printf "%s\n" "${MATCHING}" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Auto-populate PR link in artifacts
+        if: ${{ steps.check-artifact.outputs.MATCHING_FILES != '' }}
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_BRANCH: ${{ github.event.pull_request.head.ref }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          MODIFIED=false
+
+          while IFS= read -r ARTIFACT_FILE; do
+            [ -z "${ARTIFACT_FILE}" ] && continue
+
+            # Count how many changes entries exist
+            ENTRY_COUNT=$(yq '.changes | length' "${ARTIFACT_FILE}")
+
+            FILE_CHANGED=false
+            for (( i=0; i<ENTRY_COUNT; i++ )); do
+              # Check if the current PR URL is already in .changes[i].urls.pr
+              HAS_PR=$(yq ".changes[${i}].urls.pr[] | select(. == \"${PR_URL}\")" "${ARTIFACT_FILE}")
+              if [ -n "${HAS_PR}" ]; then
+                echo "PR URL already present in .changes[${i}].urls.pr of ${ARTIFACT_FILE}"
+                continue
+              fi
+
+              # Check if the list contains only empty strings
+              NON_EMPTY=$(yq ".changes[${i}].urls.pr[] | select(. != \"\")" "${ARTIFACT_FILE}")
+              if [ -z "${NON_EMPTY}" ]; then
+                # Replace the empty string(s) with the PR URL
+                yq -i ".changes[${i}].urls.pr = [\"${PR_URL}\"]" "${ARTIFACT_FILE}"
+              else
+                # Append the PR URL to the existing list
+                yq -i ".changes[${i}].urls.pr += [\"${PR_URL}\"]" "${ARTIFACT_FILE}"
+              fi
+              FILE_CHANGED=true
+            done
+
+            if [ "${FILE_CHANGED}" = true ]; then
+              MODIFIED=true
+              echo "Updated PR link in ${ARTIFACT_FILE}"
+
+              # Commit the modified file via the GitHub API (produces a verified commit)
+              FILE_SHA=$(gh api "/repos/${GITHUB_REPOSITORY}/contents/${ARTIFACT_FILE}" \
+                --jq '.sha' \
+                -H "Accept: application/vnd.github+json" \
+                -f ref="${PR_BRANCH}")
+
+              gh api --method PUT "/repos/${GITHUB_REPOSITORY}/contents/${ARTIFACT_FILE}" \
+                -H "Accept: application/vnd.github+json" \
+                -f message="Auto-populate PR link in release artifact" \
+                -f content="$(base64 -w 0 < "${ARTIFACT_FILE}")" \
+                -f sha="${FILE_SHA}" \
+                -f branch="${PR_BRANCH}" > /dev/null
+            fi
+          done <<< "${{ steps.check-artifact.outputs.MATCHING_FILES }}"
+
+          if [ "${MODIFIED}" = false ]; then
+            echo "All artifact PR links already include this PR."
+          fi
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,51 @@ jobs:
 This workflow does not check bot PRs, and the workflow skips over PRs tagged with
 the `artifact opt out` label.
 
+### Check for change artifact compliance with auto-populated PR links
+
+[`.github/workflows/pr-compliance-autofill.yml`](.github/workflows/pr-compliance-autofill.yml)
+extends the compliance check above by automatically populating the PR link in
+change artifacts. When a PR includes a change artifact, this workflow writes the
+PR URL into the artifact's `.changes[].urls.pr` field and commits the update
+back to the PR branch.
+
+The workflow accepts an optional `token` secret. When not provided, it falls
+back to the automatic `GITHUB_TOKEN`. Pass a PAT or GitHub App token if your
+calling workflow needs write access from fork PRs (for example, when using a
+`pull_request_target` trigger).
+
+On fork PRs where the token lacks write permission, the auto-populate step is
+skipped with a warning while the compliance check still enforces artifact
+presence.
+
+Here is an example of the action to add in your product's repository:
+
+```yaml
+name: 'Check for release notes artifact'
+
+on:
+  pull_request:
+
+jobs:
+  check-change-artifacts:
+    uses: canonical/release-notes-automation/.github/workflows/pr-compliance-autofill.yml@main
+    secrets: inherit
+    with:
+      change-artifact-dir: <directory to change artifacts>
+```
+
+To override the token (for example, with a GitHub App token):
+
+```yaml
+jobs:
+  check-change-artifacts:
+    uses: canonical/release-notes-automation/.github/workflows/pr-compliance-autofill.yml@main
+    secrets:
+      token: ${{ secrets.MY_APP_TOKEN }}
+    with:
+      change-artifact-dir: <directory to change artifacts>
+```
+
 ## Instructions
 
 This section guides you on how to set up and use the Release notes automation.

--- a/example/release-notes/template/_change-artifact-template.yaml
+++ b/example/release-notes/template/_change-artifact-template.yaml
@@ -1,0 +1,16 @@
+# Version of the artifact schema
+version_schema: 2
+
+# The key holding the change(s)
+changes:
+- title: # Use past tense; keep it concise and specific
+  author: # GitHub profile (no emails, no @)
+  type: # options: major, minor, bugfix, breaking, deprecated
+  description: # Use past tense; describe how the change will affect users
+  urls:
+    pr: 
+      - "" # provide one or more links to relevant PRs
+    related_doc: # only applicable if there are documentation changes
+    related_issue: # only applicable if there's a corresponding GitHub issue
+  visibility: # options: public, internal, hidden
+  highlight: # should this change be highlighted in the introduction?


### PR DESCRIPTION
This PR updates the compliance workflow (`pr-compliance.yml`) to include an additional step to auto-populate the `pr` key with a link to the PR. This eliminates the need for the PR author to fill in the key themselves, meaning they can add a change artifact ahead of their PR's creation and allow the workflow to fill in the unknown details. This should address the pain point raised in https://github.com/canonical/traefik-k8s-operator/issues/654

I validated these changes on a private repository and confirmed that the workflow (through a bot) updated the PR with a verified (signed) commit. The screenshot below shows the commit history for the test PR:

<img width="926" height="642" alt="image" src="https://github.com/user-attachments/assets/5d660293-35e9-4ee1-9964-de2e89a8d0d6" />

In order for this workflow to work downstream, we will need to modify any downstream workflows to give `contents: write` permissions, like in this example:

```
name: 'Check for release notes artifact'

on:
  pull_request:

jobs:
  check-change-artifacts:
    permissions:
      contents: write
    uses: canonical/release-notes-automation/.github/workflows/pr-compliance.yml@main
    secrets: inherit
    with:
      change-artifact-dir: docs/release-notes/artifacts
```

Otherwise the downstream workflow will fail with this error:

```
The nested job 'check-release-note-artifact' is requesting 'contents: write', but is only allowed 'contents: read'.
```

Finally, I used Copilot while preparing this PR.